### PR TITLE
fix: building docker images via docker-setup.sh

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.blocksource.nl/pooldetective-vnext-base AS build-env
+FROM pooldetective-base AS build-env
 RUN mkdir -p /go/src/github.com/mit-dci/pooldetective/
 ADD . /go/src/github.com/mit-dci/pooldetective/
 WORKDIR /go/src/github.com/mit-dci/pooldetective/api

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,6 +1,6 @@
 # build stage
 FROM golang:alpine
-RUN apk --no-cache add bash openssh-client ca-certificates build-base git bzr mercurial gcc musl-dev pkgconfig zeromq-dev
+RUN apk --no-cache add bash openssh-client ca-certificates build-base git mercurial gcc musl-dev pkgconfig zeromq-dev
 RUN go get github.com/btcsuite/btcd/chaincfg/chainhash
 RUN go get github.com/lib/pq
 RUN go get github.com/mit-dci/lit/...

--- a/Dockerfile.blockfetcher
+++ b/Dockerfile.blockfetcher
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.blocksource.nl/pooldetective-vnext-base AS build-env
+FROM pooldetective-base AS build-env
 RUN mkdir -p /go/src/github.com/mit-dci/pooldetective/
 ADD . /go/src/github.com/mit-dci/pooldetective/
 WORKDIR /go/src/github.com/mit-dci/pooldetective/blockfetcher

--- a/Dockerfile.blockobserver
+++ b/Dockerfile.blockobserver
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.blocksource.nl/pooldetective-vnext-base AS build-env
+FROM pooldetective-base AS build-env
 RUN mkdir -p /go/src/github.com/mit-dci/pooldetective/
 ADD . /go/src/github.com/mit-dci/pooldetective/
 WORKDIR /go/src/github.com/mit-dci/pooldetective/blockobserver/cmd/observer

--- a/Dockerfile.blockobserverhost
+++ b/Dockerfile.blockobserverhost
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.blocksource.nl/pooldetective-vnext-base AS build-env
+FROM pooldetective-base AS build-env
 RUN mkdir -p /go/src/github.com/mit-dci/pooldetective/
 ADD . /go/src/github.com/mit-dci/pooldetective/
 WORKDIR /go/src/github.com/mit-dci/pooldetective/hub/cmd/blockobserverhost

--- a/Dockerfile.coordinator
+++ b/Dockerfile.coordinator
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.blocksource.nl/pooldetective-vnext-base AS build-env
+FROM pooldetective-base AS build-env
 RUN rm -rf /go/src/github.com/docker/docker/vendor/github.com/docker/go-connections
 RUN mkdir -p /go/src/github.com/mit-dci/pooldetective/
 ADD . /go/src/github.com/mit-dci/pooldetective/

--- a/Dockerfile.coordinatorhost
+++ b/Dockerfile.coordinatorhost
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.blocksource.nl/pooldetective-vnext-base AS build-env
+FROM pooldetective-base AS build-env
 RUN mkdir -p /go/src/github.com/mit-dci/pooldetective/
 ADD . /go/src/github.com/mit-dci/pooldetective/
 WORKDIR /go/src/github.com/mit-dci/pooldetective/hub/cmd/coordinatorhost

--- a/Dockerfile.dbqueries
+++ b/Dockerfile.dbqueries
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.blocksource.nl/pooldetective-vnext-base AS build-env
+FROM pooldetective-base AS build-env
 RUN mkdir -p /go/src/github.com/mit-dci/pooldetective/
 ADD . /go/src/github.com/mit-dci/pooldetective/
 WORKDIR /go/src/github.com/mit-dci/pooldetective/dbqueries

--- a/Dockerfile.jobcoinbase
+++ b/Dockerfile.jobcoinbase
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.blocksource.nl/pooldetective-vnext-base AS build-env
+FROM pooldetective-base AS build-env
 RUN mkdir -p /go/src/github.com/mit-dci/pooldetective/
 ADD . /go/src/github.com/mit-dci/pooldetective/
 WORKDIR /go/src/github.com/mit-dci/pooldetective/jobcoinbase

--- a/Dockerfile.pubsubhost
+++ b/Dockerfile.pubsubhost
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.blocksource.nl/pooldetective-vnext-base AS build-env
+FROM pooldetective-base AS build-env
 RUN mkdir -p /go/src/github.com/mit-dci/pooldetective/
 ADD . /go/src/github.com/mit-dci/pooldetective/
 WORKDIR /go/src/github.com/mit-dci/pooldetective/hub/cmd/pubsubhost

--- a/Dockerfile.stratumclient
+++ b/Dockerfile.stratumclient
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.blocksource.nl/pooldetective-vnext-base AS build-env
+FROM pooldetective-base AS build-env
 RUN mkdir -p /go/src/github.com/mit-dci/pooldetective/
 ADD . /go/src/github.com/mit-dci/pooldetective/
 WORKDIR /go/src/github.com/mit-dci/pooldetective/stratum/cmd/client

--- a/Dockerfile.stratumclienthost
+++ b/Dockerfile.stratumclienthost
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.blocksource.nl/pooldetective-vnext-base AS build-env
+FROM pooldetective-base AS build-env
 RUN mkdir -p /go/src/github.com/mit-dci/pooldetective/
 ADD . /go/src/github.com/mit-dci/pooldetective/
 WORKDIR /go/src/github.com/mit-dci/pooldetective/hub/cmd/stratumclienthost

--- a/Dockerfile.stratumserver
+++ b/Dockerfile.stratumserver
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.blocksource.nl/pooldetective-vnext-base AS build-env
+FROM pooldetective-base AS build-env
 RUN mkdir -p /go/src/github.com/mit-dci/pooldetective/
 ADD . /go/src/github.com/mit-dci/pooldetective/
 WORKDIR /go/src/github.com/mit-dci/pooldetective/stratum/cmd/server


### PR DESCRIPTION
This PR removes the private registry from the `Dockerimage.*` files and renames the base image to the image that is produced when `Dockerfile.base` is build with the `docker-build.sh` script. Additionally, the `bzr` dependency in the `Dockerfile.base` build is removed as it's not longer present in the `alpine:latest` image which the used `golang:alpine` image is based on.

This fixes #1. 