### PR TITLE
fix: correctly set env var POSTGRES_PASSWORD

### DIFF
--- a/localdocker/docker-compose.yml
+++ b/localdocker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./data/postgres:/var/lib/postgresql/data
       - ./data/database:/tmp/database
     environment:
-      - POSTGRES_PASSWORD:pooldetective
+      - POSTGRES_PASSWORD=pooldetective
     networks:
       - pooldetective
 


### PR DESCRIPTION
An equal sign (=) is required for environment variable assignment.

Previously, an environment variable `POSTGRES_PASSWORD:pooldetective`
was set but didn't have any value assigned. This resulted in
PostgreSQL shutting down. The sample data could not be inserted.

Log of the issue:
```
Starting up just the database server so we can import the PoolDetective schema and demo data

Creating network "localdocker_pooldetective" with driver "bridge"
Creating localdocker_postgres_1 ... done

Importing schema and demo data

ERROR: No container found for postgres_1
```

The 'postgres' service defined in the docker-compose.yml was already
shutdown by the time the sample data was about to be inserted.